### PR TITLE
Use DeviseFallbackHandler to be compatible with newer versions of simple_token_authentication

### DIFF
--- a/lib/devise-ios-rails.rb
+++ b/lib/devise-ios-rails.rb
@@ -43,7 +43,9 @@ module DeviseIosRails
           end
         end
 
-        SimpleTokenAuthentication::FallbackAuthenticationHandler.class_eval do
+        annotate_class = (SimpleTokenAuthentication.const_defined? 'FallbackAuthenticationHandler') ? 'FallbackAuthenticationHandler' : 'DeviseFallbackHandler'
+        annotate_class = 'SimpleTokenAuthentication::' + annotate_class
+        annotate_class.constantize.class_eval do
           def authenticate_entity!(controller, entity)
             controller.send("authenticate_#{entity.name_underscore}!".to_sym, force: true)
           end


### PR DESCRIPTION
As requested in #6, this PR should be backwards compatible with older versions of simple_token_authentication as well.

#16 is also required, otherwise the authentication_token will not be set properly.